### PR TITLE
stop hunting if persist ist false and out is noop

### DIFF
--- a/src/hunt.js
+++ b/src/hunt.js
@@ -139,7 +139,7 @@
           // when hunting should not persist remove element
           if (hunted.out === noop && !hunted.persist) {
             this._huntedElements.splice(len, 1);
-          
+
             // end observer activity when there are no more elements
             if (this._huntedElements.length === 0) {
               this.disconnect();

--- a/src/hunt.js
+++ b/src/hunt.js
@@ -135,6 +135,16 @@
       if (!hunted.visible && isOnViewport) {
           hunted.enter.call(this, hunted.element);
           hunted.visible = true;
+
+          // when hunting should not persist remove element
+          if (hunted.out === noop && !hunted.persist) {
+            this._huntedElements.splice(len, 1);
+          
+            // end observer activity when there are no more elements
+            if (this._huntedElements.length === 0) {
+              this.disconnect();
+            }
+          }
         }
 
       /*

--- a/src/hunt.js
+++ b/src/hunt.js
@@ -136,7 +136,7 @@
           hunted.enter.call(this, hunted.element);
           hunted.visible = true;
 
-          // when hunting should not persist remove element
+          // when the out callback method is not set and hunting should not persist remove element
           if (hunted.out === noop && !hunted.persist) {
             this._huntedElements.splice(len, 1);
 


### PR DESCRIPTION
I have the case that I have hunted elements. Some of them never trigger `out` as they are always visible in many cases.

The `out`  callback is not defined in this case. I have to create an array and set the visible state in the enter callback using the index of this array, use `Array.every` and manually call `disconnect` as they never trigger `out`.

So it is not necessary to still hunt the elements after this as just the `enter` callback is used.

You can see on https://sicherheit.daniel-ruf.de how I solved this without this fix.