### PR TITLE
Ensure throttle always invokes the function at the end of the throttle interval

### DIFF
--- a/dist/hunt.js
+++ b/dist/hunt.js
@@ -1,4 +1,4 @@
-/* Hunt v4.0.0 - 2017 Jeremias Menichelli - MIT License */
+/* Hunt v4.0.1 - 2017 Jeremias Menichelli - MIT License */
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
@@ -21,18 +21,42 @@
    * @returns {Function}
    */
   var throttle = function(fn) {
-    var timer = null;
+    var inThrottle;
+    var lastFunc;
+    var lastRan;
 
-    return function throttledAction() {
-      if (timer) {
-        return;
+    return function() {
+      var args = arguments;
+
+      if (inThrottle) {
+        clearTimeout(lastFunc);
+        lastFunc = setTimeout(function () {
+          if (Date.now() - lastRan >= THROTTLE_INTERVAL) {
+            fn.apply(this, args);
+            lastRan = Date.now();
+          }
+        }, THROTTLE_INTERVAL - (Date.now() - lastRan));
+      } else {
+        fn.apply(this, args);
+        lastRan = Date.now();
+        inThrottle = true;
       }
-      timer = setTimeout(function () {
-        fn.apply(this, arguments);
-        timer = null;
-      }, THROTTLE_INTERVAL);
     };
   };
+
+  // var throttle = function(fn) {
+  //   var timer = null;
+
+  //   return function throttledAction() {
+  //     if (timer) {
+  //       return;
+  //     }
+  //     timer = setTimeout(function () {
+  //       fn.apply(this, arguments);
+  //       timer = null;
+  //     }, THROTTLE_INTERVAL);
+  //   };
+  // };
 
   /**
    * Assign throttled actions and add listeners

--- a/dist/hunt.js
+++ b/dist/hunt.js
@@ -44,20 +44,6 @@
     };
   };
 
-  // var throttle = function(fn) {
-  //   var timer = null;
-
-  //   return function throttledAction() {
-  //     if (timer) {
-  //       return;
-  //     }
-  //     timer = setTimeout(function () {
-  //       fn.apply(this, arguments);
-  //       timer = null;
-  //     }, THROTTLE_INTERVAL);
-  //   };
-  // };
-
   /**
    * Assign throttled actions and add listeners
    * @method _connect

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "huntjs",
   "title": "Hunt",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Light-weight library to observe nodes entering and leaving the viewport",
   "main": "dist/hunt.js",
   "repository": {

--- a/src/hunt.js
+++ b/src/hunt.js
@@ -37,20 +37,6 @@ var throttle = function(fn) {
   };
 };
 
-// var throttle = function(fn) {
-//   var timer = null;
-
-//   return function throttledAction() {
-//     if (timer) {
-//       return;
-//     }
-//     timer = setTimeout(function () {
-//       fn.apply(this, arguments);
-//       timer = null;
-//     }, THROTTLE_INTERVAL);
-//   };
-// };
-
 /**
  * Assign throttled actions and add listeners
  * @method _connect

--- a/src/hunt.js
+++ b/src/hunt.js
@@ -14,18 +14,42 @@ var noop = function() {};
  * @returns {Function}
  */
 var throttle = function(fn) {
-  var timer = null;
+  var inThrottle;
+  var lastFunc;
+  var lastRan;
 
-  return function throttledAction() {
-    if (timer) {
-      return;
+  return function() {
+    var args = arguments;
+
+    if (inThrottle) {
+      clearTimeout(lastFunc);
+      lastFunc = setTimeout(function () {
+        if (Date.now() - lastRan >= THROTTLE_INTERVAL) {
+          fn.apply(this, args);
+          lastRan = Date.now();
+        }
+      }, THROTTLE_INTERVAL - (Date.now() - lastRan));
+    } else {
+      fn.apply(this, args);
+      lastRan = Date.now();
+      inThrottle = true;
     }
-    timer = setTimeout(function () {
-      fn.apply(this, arguments);
-      timer = null;
-    }, THROTTLE_INTERVAL);
   };
 };
+
+// var throttle = function(fn) {
+//   var timer = null;
+
+//   return function throttledAction() {
+//     if (timer) {
+//       return;
+//     }
+//     timer = setTimeout(function () {
+//       fn.apply(this, arguments);
+//       timer = null;
+//     }, THROTTLE_INTERVAL);
+//   };
+// };
 
 /**
  * Assign throttled actions and add listeners


### PR DESCRIPTION
When scrolling too fast, the current throttle could miss invoking the function if its still within the interval. I'm using hunt for lazy loading content, and every so often hunt will miss the observable element when scrolling too fast. This PR will ensure that the the function is called after the throttle interval, so even when scrolling too fast, it'll still be called.

Another option is to use `requestAnimationFrame` and let the browser handle when to update.

EDIT: Credit to the function in this post: https://medium.com/@_jh3y/throttling-and-debouncing-in-javascript-b01cad5c8edf — I just modified it to fit in the eslint rules.